### PR TITLE
docs(readme): add Recent changes note for PR #37 (JQL migration) [TEST1-200]

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ Give it a Notion page (or a Jira ticket) and a target repo. It reads the require
 
 ---
 
+## Recent changes
+
+- **#37** Migrated `fetch_pending_jira` from deprecated `GET /rest/api/3/search` to `POST /rest/api/3/search/jql`.
+
+---
+
 ## Install
 
 ### As a Claude Code Plugin (recommended)


### PR DESCRIPTION
## Summary

Implements **[TEST1-200](https://degreesight.atlassian.net/browse/TEST1-200)** — adds a one-line note to README.md acknowledging the recently-merged #37 JQL migration.

This is the **first end-to-end run of MorningStar live mode** against the new `/search/jql` endpoint that #37 introduced. It validates the full Slack → Kronk gateway → MorningStar → Claude Code → GitHub PR pipeline.

## What changed

```diff
+## Recent changes
+
+- **#37** Migrated \`fetch_pending_jira\` from deprecated \`GET /rest/api/3/search\` to \`POST /rest/api/3/search/jql\`.
```

That's it. No code, no tests touched.

## How this PR was authored

End-to-end by the autonomous loop:

1. **Jira** — TEST1-200 was created with `morningstar` + `agent-ready` labels and a concrete acceptance criterion.
2. **MorningStar** ran `process-queue --max-tasks 1` against this repo.
3. **`fetch_pending_jira`** (the function #37 fixed) successfully scanned TEST1 via `POST /search/jql` and returned the ticket. **Without #37, this returns 0.**
4. **Claude Code** — `claude -p ... --permission-mode dontAsk --max-budget-usd 5.00 --output-format json`. 10 turns, `$0.12` spend, `success`. Edited README.md and ran `pytest` (152 / 152 green).
5. **Kronk operator** finalized the commit + push + PR (MorningStar's `git add` step hit a non-fatal issue with `.agent-logs/` exclusion patterns; queued as a follow-up upstream fix).

## Verification

```bash
python -m pytest tests/   # 152 passed in 0.88s
```

## Follow-up upstream items (not in this PR)

- `fetch_pending_jira` defaults `pending_status="To Do"` — Jira projects with non-default workflows (e.g. statuses `Backlog`, `Selected for Development`) need either a CLI flag or `statusCategory`-based JQL. Tracked as a follow-up.
- The `git add` step in `process-queue` should respect `_GIT_EXCLUDE_PATTERNS` so `.agent-logs/` doesn't break staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via MorningStar via Kronk