### PR TITLE
feat(jira): configurable pending_status + statusCategory override

### DIFF
--- a/src/morningstar/cli.py
+++ b/src/morningstar/cli.py
@@ -376,6 +376,22 @@ def process_queue_cmd(
         "", "--jira-project", envvar="MORNINGSTAR_JIRA_PROJECT_KEY"
     ),
     jira_label: str = typer.Option("morningstar", "--jira-label"),
+    jira_pending_status: str = typer.Option(
+        "To Do", "--jira-pending-status",
+        envvar="MORNINGSTAR_JIRA_PENDING_STATUS",
+        help="Exact Jira status name treated as 'pending'. Default 'To Do' "
+        "matches a default Jira workflow; for projects with renamed statuses "
+        "(e.g. 'Backlog', 'Selected for Development'), set this OR use "
+        "--jira-pending-status-category for cross-workflow portability.",
+    ),
+    jira_pending_status_category: str = typer.Option(
+        "", "--jira-pending-status-category",
+        envvar="MORNINGSTAR_JIRA_PENDING_STATUS_CATEGORY",
+        help="Jira statusCategory key (one of: 'new', 'indeterminate', "
+        "'done'). When set, takes precedence over --jira-pending-status. "
+        "'new' matches every workflow's pending-style states (To Do, Backlog, "
+        "Selected for Development, etc.) — recommended for cross-project use.",
+    ),
     gh_repo: str = typer.Option("", "--gh-repo", envvar="MORNINGSTAR_GH_REPO"),
     base_branch: str = typer.Option("main", "--base-branch"),
     slack_webhook: str = typer.Option(
@@ -438,6 +454,8 @@ def process_queue_cmd(
         jira_token=jira_token,
         jira_project_key=jira_project_key,
         jira_label=jira_label,
+        jira_pending_status=jira_pending_status,
+        jira_pending_status_category=jira_pending_status_category,
         gh_repo=gh_repo,
         base_branch=base_branch,
         slack_webhook=slack_webhook,

--- a/src/morningstar/engine.py
+++ b/src/morningstar/engine.py
@@ -807,14 +807,27 @@ def fetch_pending_jira(
     *,
     label: str = "morningstar",
     pending_status: str = "To Do",
+    pending_status_category: str = "",
 ) -> list[PendingItem]:
-    """Query Jira for tickets with the given label in Pending status."""
+    """Query Jira for tickets with the given label in Pending status.
+
+    Status filter: ``pending_status_category`` (when truthy) generates a JQL
+    ``statusCategory = "<value>"`` clause, which matches across Jira
+    workflows that rename "To Do" to "Backlog", "Selected for Development",
+    etc. — Atlassian guarantees three category keys (``new``,
+    ``indeterminate``, ``done``) that every workflow maps to. Otherwise the
+    legacy exact ``status = "<pending_status>"`` clause is used.
+    """
     base_url = validate_jira_url(base_url)
     validate_jira_project_key(project_key)
 
+    if pending_status_category:
+        status_clause = f'statusCategory = "{pending_status_category}"'
+    else:
+        status_clause = f'status = "{pending_status}"'
     jql = (
         f'project = {project_key} AND labels = "{label}" '
-        f'AND status = "{pending_status}"'
+        f'AND {status_clause}'
     )
     # Atlassian removed GET /rest/api/3/search on 2025-08-01 (returns 410
     # Gone). Use POST /rest/api/3/search/jql with a JSON body and a list
@@ -1104,6 +1117,11 @@ class QueueConfig:
     jira_token: str = ""
     jira_project_key: str = ""
     jira_label: str = "morningstar"
+    jira_pending_status: str = "To Do"  # exact Jira status name to scan; or...
+    jira_pending_status_category: str = ""  # ...statusCategory key (e.g. "new"),
+    # which matches across Jira workflows that rename "To Do" to "Backlog",
+    # "Selected for Development", etc. When set, takes precedence over
+    # jira_pending_status. Standard categories: "new", "indeterminate", "done".
     # Delivery
     gh_repo: str = ""  # owner/name -- for PR creation
     base_branch: str = "main"
@@ -1179,6 +1197,8 @@ def _gather_pending(cfg: QueueConfig) -> list[PendingItem]:
             cfg.jira_url, cfg.jira_project_key,
             cfg.jira_email, cfg.jira_token,
             label=cfg.jira_label,
+            pending_status=cfg.jira_pending_status,
+            pending_status_category=cfg.jira_pending_status_category,
         ))
     return items
 

--- a/tests/test_process_queue.py
+++ b/tests/test_process_queue.py
@@ -230,6 +230,53 @@ class TestFetchPendingJira:
         assert items[0].prd_url == ""
         assert "No URL here" in items[0].inline_prd_text
 
+    @patch("morningstar.engine.httpx.post")
+    def test_pending_status_default_uses_status_clause(
+        self, mock_post: MagicMock,
+    ) -> None:
+        """Default behavior: JQL filters by exact status name 'To Do'."""
+        mock_post.return_value = MagicMock(json=lambda: {"issues": []})
+        mock_post.return_value.raise_for_status = lambda: None
+
+        fetch_pending_jira(
+            "https://x.atlassian.net", "ABC", "me@x.com", "token",
+        )
+        body = mock_post.call_args[1]["json"]
+        assert 'status = "To Do"' in body["jql"]
+        assert "statusCategory" not in body["jql"]
+
+    @patch("morningstar.engine.httpx.post")
+    def test_pending_status_override(self, mock_post: MagicMock) -> None:
+        """Caller can override exact status name (e.g. 'Backlog')."""
+        mock_post.return_value = MagicMock(json=lambda: {"issues": []})
+        mock_post.return_value.raise_for_status = lambda: None
+
+        fetch_pending_jira(
+            "https://x.atlassian.net", "ABC", "me@x.com", "token",
+            pending_status="Backlog",
+        )
+        body = mock_post.call_args[1]["json"]
+        assert 'status = "Backlog"' in body["jql"]
+
+    @patch("morningstar.engine.httpx.post")
+    def test_pending_status_category_takes_precedence(
+        self, mock_post: MagicMock,
+    ) -> None:
+        """When pending_status_category is set, JQL uses statusCategory and
+        ignores pending_status — covers cross-workflow projects (where
+        'pending' status names vary)."""
+        mock_post.return_value = MagicMock(json=lambda: {"issues": []})
+        mock_post.return_value.raise_for_status = lambda: None
+
+        fetch_pending_jira(
+            "https://x.atlassian.net", "ABC", "me@x.com", "token",
+            pending_status="ignored-when-category-set",
+            pending_status_category="new",
+        )
+        body = mock_post.call_args[1]["json"]
+        assert 'statusCategory = "new"' in body["jql"]
+        assert "ignored-when-category-set" not in body["jql"]
+
 
 class TestSetJiraStatus:
     @patch("morningstar.engine.httpx.post")


### PR DESCRIPTION
## Summary

\`fetch_pending_jira\` hard-codes \`status = \"To Do\"\`, which silently returns **0 results** on every Jira project whose workflow renames the default pending column. That covers most non-vanilla setups: Backlog, Selected for Development, Sprint Backlog, etc. The CLI exposed no override.

This PR adds two hooks for cross-workflow portability:

| Hook | Env var | Default | When to use |
|---|---|---|---|
| \`--jira-pending-status\` | \`MORNINGSTAR_JIRA_PENDING_STATUS\` | \`To Do\` | One project, known status name |
| \`--jira-pending-status-category\` | \`MORNINGSTAR_JIRA_PENDING_STATUS_CATEGORY\` | (unset) | Cross-project / unknown workflow |

When both are set, \`statusCategory\` takes precedence. \`statusCategory = \"new\"\` matches every workflow's pending-style states because Atlassian guarantees three category keys (\`new\`, \`indeterminate\`, \`done\`) that every workflow maps to — independent of how the team named the actual statuses.

## Why this matters

Without this, anyone running \`morningstar process-queue\` against a Jira project with a non-default workflow gets a zero-item scan and no error — just a silent no-op. Discovered while running live mode against TEST1 (whose workflow uses \`Backlog\` instead of \`To Do\`); found 10 \`morningstar\`-labeled tickets via direct JQL but \`fetch_pending_jira\` returned 0 because it hard-coded the status name.

## Changes

- \`src/morningstar/engine.py\`: \`fetch_pending_jira\` accepts \`pending_status_category\`. \`QueueConfig\` gains \`jira_pending_status\` + \`jira_pending_status_category\` fields. \`_gather_pending\` plumbs both through.
- \`src/morningstar/cli.py\`: two new typer options with envvar wiring.
- \`tests/test_process_queue.py\`: 3 new tests — default preserves \`status = \"To Do\"\` clause, override flips to a custom status, category takes precedence and ignores \`pending_status\`.

## Verification

\`\`\`bash
python -m pytest tests/ -q
# 155 passed in 0.84s   (was 152)
\`\`\`

Backwards-compatible: every existing call site keeps the old behavior because the new parameters default to \`pending_status=\"To Do\"\` and \`pending_status_category=\"\"\`.

## Recommended usage

For projects with non-default workflows (TEST1, DEG with sprints, anything with renamed pending statuses), use:

\`\`\`bash
export MORNINGSTAR_JIRA_PENDING_STATUS_CATEGORY=new
morningstar process-queue --repo /path/to/target
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)