### PR TITLE
fix(git): tolerate benign 'paths ignored' warnings on add (no-PR bug)

### DIFF
--- a/src/morningstar/engine.py
+++ b/src/morningstar/engine.py
@@ -601,8 +601,32 @@ def _git_commit(repo_path: Path, title: str, task_id: str) -> None:
             capture_output=True,
             timeout=30,
         )
+        # `git add` can return a nonzero status with a benign "paths are
+        # ignored by .gitignore" warning when an exclude pathspec matches
+        # a gitignored path (e.g. `.agent-logs/` is both pathspec-excluded
+        # AND gitignored). The warning is informational; the gating
+        # signal we actually care about is whether anything ended up
+        # staged. So instead of bailing on the warning, treat it as
+        # debug-level and consult the index directly below.
         if add_result.returncode != 0:
-            logger.warning("git add failed: %s", add_result.stderr)
+            logger.debug("git add stderr (treated as informational): %s",
+                         add_result.stderr)
+
+        staged = subprocess.run(
+            ["git", "diff", "--cached", "--name-only"],
+            cwd=str(repo_path),
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if not staged.stdout.strip():
+            stderr_text = add_result.stderr.decode(errors="replace") if isinstance(
+                add_result.stderr, bytes) else (add_result.stderr or "")
+            logger.warning(
+                "git add produced no staged changes; skipping commit. "
+                "stderr from add: %s",
+                stderr_text,
+            )
             return
 
         commit_result = subprocess.run(

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -475,15 +475,17 @@ class TestGitCommit:
             subprocess.CompletedProcess(args=[], returncode=0, stdout="M file.py\n", stderr=""),
             # git add
             subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+            # git diff --cached --name-only (something staged)
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="file.py\n", stderr=""),
             # git commit
             subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
         ]
 
         _git_commit(tmp_repo, "my feature", "task-1")
-        assert mock_run.call_count == 3
+        assert mock_run.call_count == 4
 
         # Check commit message
-        commit_cmd = mock_run.call_args_list[2][0][0]
+        commit_cmd = mock_run.call_args_list[3][0][0]
         assert "feat: my feature" in commit_cmd[-1]
         assert "MorningStar" in commit_cmd[-1]
 
@@ -492,6 +494,7 @@ class TestGitCommit:
         mock_run.side_effect = [
             subprocess.CompletedProcess(args=[], returncode=0, stdout="M file.py\n", stderr=""),
             subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="file.py\n", stderr=""),
             subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
         ]
 
@@ -502,6 +505,57 @@ class TestGitCommit:
         assert ":!*.pem" in add_cmd
         assert ":!*.key" in add_cmd
         assert ":!.agent-logs" in add_cmd
+
+    @patch("morningstar.engine.subprocess.run")
+    def test_tolerates_add_warning_when_index_has_changes(
+        self, mock_run: MagicMock, tmp_repo: Path,
+    ) -> None:
+        """git add can return rc!=0 with a benign 'paths are ignored by
+        .gitignore' warning when an exclude pathspec matches a gitignored
+        directory (e.g. .agent-logs/). The commit should still proceed
+        if anything is actually staged."""
+        mock_run.side_effect = [
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="M file.py\n", stderr=""),
+            # git add returns nonzero with the benign warning
+            subprocess.CompletedProcess(
+                args=[], returncode=1, stdout="",
+                stderr=b"The following paths are ignored by one of your "
+                       b".gitignore files:\n.agent-logs\nhint: Use -f if "
+                       b"you really want to add them.\n",
+            ),
+            # but the index still has the README change staged
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="file.py\n", stderr=""),
+            # commit succeeds
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+        ]
+
+        _git_commit(tmp_repo, "fix", "task-1")
+        assert mock_run.call_count == 4
+        # Confirm we reached the commit step
+        commit_cmd = mock_run.call_args_list[3][0][0]
+        assert commit_cmd[:2] == ["git", "commit"]
+
+    @patch("morningstar.engine.subprocess.run")
+    def test_skips_commit_when_nothing_actually_staged(
+        self, mock_run: MagicMock, tmp_repo: Path,
+    ) -> None:
+        """If git add genuinely fails to stage anything, don't try to
+        commit — that just produces a confusing 'nothing to commit'
+        error. Skip cleanly."""
+        mock_run.side_effect = [
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="M file.py\n", stderr=""),
+            subprocess.CompletedProcess(
+                args=[], returncode=1, stdout="",
+                stderr=b"The following paths are ignored by one of your "
+                       b".gitignore files:\n.agent-logs\n",
+            ),
+            # nothing staged
+            subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+        ]
+
+        _git_commit(tmp_repo, "fix", "task-1")
+        # status, add, diff-cached -> 3 calls. No commit attempted.
+        assert mock_run.call_count == 3
 
     @patch("morningstar.engine.subprocess.run")
     def test_handles_git_not_found(self, mock_run: MagicMock, tmp_repo: Path) -> None:


### PR DESCRIPTION
## The bug

\`_git_commit\` bails on the add step if \`git add\` returns nonzero — but \`git add -A -- :!.agent-logs ...\` returns nonzero with a benign **"The following paths are ignored by one of your .gitignore files"** warning when an exclude pathspec happens to also match a gitignored directory.

Result: tickets that completed successfully (Claude edited files, tests passed, branch was pushed) had **no commits on the branch**, so the subsequent \`gh pr create\` failed with "No commits between main and morningstar/<task>". From the operator's view: the work appeared to succeed but no PR was opened.

## The fix

Don't return on the add warning. Instead, consult the index (\`git diff --cached --name-only\`) to determine whether anything was actually staged. Commit if yes, skip cleanly if no.

The benign warning is now emitted at \`debug\` level and only surfaces in the operator-facing log if no files are staged — at which point it's useful diagnostic information.

## Real-world repro that motivated this

Live mode hit this exact path on TEST1-200:

\`\`\`text
git add failed: b'The following paths are ignored by one of your .gitignore files:
.agent-logs
hint: Use -f if you really want to add them.'

gh pr create failed: pull request create failed: GraphQL: No commits
between main and morningstar/jira-test1-200 (createPullRequest)
\`\`\`

The branch existed, the README change was waiting in the working tree, but the add step's nonzero exit caused \`_git_commit\` to skip the commit. \`pytest\` had passed; cost was \$0.12 — but no PR.

I manually completed the PR for that run (lonexreb/morningstar#38). With this fix, the next \`process-queue\` run lands its own PR without operator intervention.

## Changes

- \`src/morningstar/engine.py\`: split the add step's nonzero-exit handling from the commit decision. New step: \`git diff --cached --name-only\` after add. Commit if anything is staged; skip otherwise.
- \`tests/test_engine.py\`: existing tests updated to expect 4 subprocess calls instead of 3 (the new diff-cached check). Two new tests cover the benign-warning path:
  - \`test_tolerates_add_warning_when_index_has_changes\` — exact replay of the TEST1-200 failure mode.
  - \`test_skips_commit_when_nothing_actually_staged\` — same warning but nothing in the index, asserts no commit attempt.

## Verification

\`\`\`bash
python -m pytest tests/ -q
# 154 passed in 0.85s   (was 152)
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)