### PR TITLE
feat(jira): set_jira_status accepts list of fallback transition names

### DIFF
--- a/src/morningstar/engine.py
+++ b/src/morningstar/engine.py
@@ -864,10 +864,28 @@ def set_jira_status(
     issue_key: str,
     email: str,
     token: str,
-    transition_name: str,
+    transition_name: str | list[str],
 ) -> bool:
-    """Transition a Jira ticket by transition name (e.g. 'In Progress', 'Done')."""
+    """Transition a Jira ticket by transition name.
+
+    `transition_name` may be a single name (e.g. ``"Done"``) or a list of
+    candidate names tried in order (e.g. ``["Running", "In Progress",
+    "Selected for Development"]``). The first match against the ticket's
+    available transitions wins; later candidates are only checked if
+    earlier ones don't exist on the workflow. Returns False if none
+    match.
+
+    The list form makes the queue resilient to workflow naming
+    differences across Jira projects: the default Jira workflow has
+    "In Progress" while many teams use "Running", "Active", or
+    "Selected for Development" for the same intent.
+    """
     base_url = validate_jira_url(base_url)
+    candidates = (
+        [transition_name] if isinstance(transition_name, str) else list(transition_name)
+    )
+    if not candidates:
+        return False
 
     try:
         list_resp = httpx.get(
@@ -876,13 +894,20 @@ def set_jira_status(
             timeout=15,
         )
         list_resp.raise_for_status()
+        available = {
+            tr.get("name", "").lower(): tr.get("id")
+            for tr in list_resp.json().get("transitions", [])
+        }
         wanted = None
-        for tr in list_resp.json().get("transitions", []):
-            if tr.get("name", "").lower() == transition_name.lower():
-                wanted = tr.get("id")
+        for cand in candidates:
+            if cand.lower() in available:
+                wanted = available[cand.lower()]
                 break
         if not wanted:
-            logger.warning("Jira transition '%s' not available for %s", transition_name, issue_key)
+            logger.warning(
+                "Jira transition not available for %s (tried %s; available: %s)",
+                issue_key, candidates, sorted(available.keys()),
+            )
             return False
 
         resp = httpx.post(
@@ -1163,10 +1188,23 @@ def _mark_item(
             pr_url=pr_url, notes=notes,
         )
     elif item.source == "jira" and cfg.jira_url and cfg.jira_email and cfg.jira_token:
+        # Map our internal status intent to a list of Jira transition
+        # names to try in order. Default Jira workflow uses "In Progress"
+        # / "Done" / "Won't Do"; many teams rename or extend these (TEST1
+        # uses "Selected for Development"; some use "Active", "Running",
+        # "Closed", "Resolved", "Failed", "Blocked"). First match wins.
+        _JIRA_TRANSITION_FALLBACKS = {
+            "Running": ["Running", "In Progress", "Active",
+                        "Selected for Development", "Start Progress"],
+            "Done": ["Done", "Closed", "Resolved", "Complete", "Completed"],
+            "Failed": ["Failed", "Blocked", "Won't Do", "Cancelled",
+                       "Wont Do", "Won't Fix"],
+        }
+        candidates = _JIRA_TRANSITION_FALLBACKS.get(status, [status])
         set_jira_status(
             cfg.jira_url, item.source_id,
             cfg.jira_email, cfg.jira_token,
-            status,
+            candidates,
         )
 
 

--- a/tests/test_process_queue.py
+++ b/tests/test_process_queue.py
@@ -256,6 +256,53 @@ class TestSetJiraStatus:
         assert ok is True
         assert mock_post.call_args.kwargs["json"]["transition"]["id"] == "41"
 
+    @patch("morningstar.engine.httpx.post")
+    @patch("morningstar.engine.httpx.get")
+    def test_accepts_list_of_candidate_names(
+        self, mock_get: MagicMock, mock_post: MagicMock,
+    ) -> None:
+        """List form: try each in order, first available wins."""
+        mock_get.return_value = MagicMock(
+            json=lambda: {
+                "transitions": [
+                    {"id": "21", "name": "Selected for Development"},
+                    {"id": "41", "name": "Done"},
+                ],
+            },
+        )
+        mock_get.return_value.raise_for_status = lambda: None
+        mock_post.return_value = MagicMock(status_code=204)
+        mock_post.return_value.raise_for_status = lambda: None
+
+        ok = set_jira_status(
+            "https://x.atlassian.net", "ABC-1",
+            "me@x.com", "token",
+            ["Running", "In Progress", "Selected for Development"],
+        )
+        assert ok is True
+        # Skipped Running + In Progress (not on workflow); landed on
+        # Selected for Development.
+        assert mock_post.call_args.kwargs["json"]["transition"]["id"] == "21"
+
+    @patch("morningstar.engine.httpx.post")
+    @patch("morningstar.engine.httpx.get")
+    def test_returns_false_when_no_candidate_matches(
+        self, mock_get: MagicMock, mock_post: MagicMock,
+    ) -> None:
+        mock_get.return_value = MagicMock(
+            json=lambda: {"transitions": [{"id": "41", "name": "Done"}]},
+        )
+        mock_get.return_value.raise_for_status = lambda: None
+
+        ok = set_jira_status(
+            "https://x.atlassian.net", "ABC-1",
+            "me@x.com", "token",
+            ["Running", "Active"],
+        )
+        assert ok is False
+        # POST should not have been called at all.
+        assert not mock_post.called
+
 
 # ── Weekly budget ─────────────────────────────────────────────
 


### PR DESCRIPTION
## Why

\`_mark_item\` calls \`set_jira_status\` with literal status names like \`"Running"\`, \`"Done"\`, \`"Failed"\`. Default Jira workflow uses \`"In Progress"\` / \`"Done"\` / \`"Won't Do"\`, but many teams rename or extend these:

- TEST1 uses **Selected for Development**
- Some teams use **Active** or **Running**
- Closed states vary: **Closed**, **Resolved**, **Complete**, **Completed**
- Failed/blocked states vary: **Blocked**, **Won't Do**, **Won't Fix**, **Cancelled**

When set_jira_status got a name that wasn't on the workflow it logged a warning and returned False, but no fallback was attempted — the ticket stayed unchanged. Discovered while running live mode against TEST1-200:

\`\`\`text
Jira transition 'Running' not available for TEST1-200
\`\`\`

## What

\`set_jira_status\` now accepts \`transition_name: str | list[str]\`:
- **String form**: unchanged behavior, fully backwards compatible.
- **List form**: tries each candidate in order; first match against the ticket's available transitions wins.

\`_mark_item\` (the sole internal caller) now passes intent-keyed fallback lists:

\`\`\`python
"Running": ["Running", "In Progress", "Active",
            "Selected for Development", "Start Progress"],
"Done":    ["Done", "Closed", "Resolved", "Complete", "Completed"],
"Failed":  ["Failed", "Blocked", "Won't Do", "Cancelled",
            "Wont Do", "Won't Fix"],
\`\`\`

The "available transitions" log line is also more useful — prints **both** the candidates tried AND what's actually on the workflow, so operators can see the gap immediately and add their own custom name if needed.

## Tests

- Existing tests pass (string form is fully backwards compatible).
- New: list-form returns True and lands on the first available transition (skipping unavailable earlier candidates).
- New: returns False cleanly when no candidate matches; verifies no POST is attempted.

\`\`\`bash
python -m pytest tests/ -q
# 154 passed in 0.76s   (was 152)
\`\`\`

## Companion PRs

This is the third in a series fixing live-mode end-to-end blockers found while running TEST1-200:

- #37 (merged) — \`/search/jql\` migration
- #38 (open) — first PR authored end-to-end via the loop (the README note)
- #39 (open) — \`fetch_pending_jira\` configurable pending_status / statusCategory
- #40 (open) — git add tolerates benign 'paths ignored by .gitignore' warnings
- **#41 (this PR)** — set_jira_status fallback transition names

Together, these unblock live mode for any Jira project workflow without manual operator finalization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)